### PR TITLE
chore: corrects product name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 OpenTSDB on Bigtable
 ============
 
-This solution deploys OpenTSDB on Google Container Engine and uses Cloud Bigtable as its underlying storage. It also deploys Grafana for visualization.
+This solution deploys OpenTSDB on Google Kubernetes Engine and uses Cloud Bigtable as its underlying storage. It also deploys Grafana for visualization.
 
 
 The guide can be found at:


### PR DESCRIPTION
Feel free to reject but seems on all public docs we now refer to this product as GKE - I guess to avoid confusion with Google Compute Engine (GCE).