### PR TITLE
Sample event generator

### DIFF
--- a/deployments/generate.yaml
+++ b/deployments/generate.yaml
@@ -1,0 +1,30 @@
+# Copyright 2021 Google, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: generate-opentsdb
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: generate-opentsdb
+  template:
+    metadata:
+      labels:
+        app: generate-opentsdb
+    spec:
+      containers:
+      - name: generate-opentsdb
+        image: gcr.io/cloud-solutions-images/opentsdb-gen:0.1.1

--- a/generate-ts/build.sh
+++ b/generate-ts/build.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# Copyright 2021 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+rm -Rf build/src
+mkdir build/src
+cp gen.py build/src
+cp requirements.txt build/src
+docker build build
+rm -Rf build/src

--- a/generate-ts/build/Dockerfile
+++ b/generate-ts/build/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2021 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM python:3.8
+
+WORKDIR /gen
+
+COPY src/requirements.txt .
+RUN pip install -r /gen/requirements.txt
+COPY src/gen.py .
+
+CMD ["python", "./gen.py"]

--- a/generate-ts/gen.py
+++ b/generate-ts/gen.py
@@ -1,0 +1,50 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Generate random time series events and post to the
+OpenTSDB rest endpoint every 1 second.
+Args:
+    host: OpenTSDB service endpoint (default: opentsdb-write)
+"""
+
+import json
+import time
+import random
+import requests
+import sys
+import logging
+
+host = "opentsdb-write"
+if len(sys.argv) > 1:
+    host = sys.argv[1];
+
+while True:
+    a=[]
+    for i in range(0, 5):
+        cpu = {}
+        cpu["timestamp"] = int(time.time()*1000)
+        cpu["metric"] = "cpu_node_utilization_gauge"
+        cpu["value"] = random.uniform(0,1)
+        cpu["tags"] = {"host": "host%d" %i}
+        a.append(cpu)
+        mem = {}
+        mem["timestamp"] = int(time.time()*1000)
+        mem["metric"] = "memory_usage_gauge"
+        mem["value"] = random.uniform(1,10)
+        mem["tags"] = {"host": "host%d" %i}
+        a.append(mem)
+    r = requests.post("http://%s:4242/api/put?details" %host, json=a)
+    logging.info(r.content)
+    time.sleep(5)

--- a/generate-ts/requirements.txt
+++ b/generate-ts/requirements.txt
@@ -1,0 +1,1 @@
+requests


### PR DESCRIPTION
Heapster has been [deprecated](https://github.com/kubernetes-retired/heapster/blob/master/docs/deprecation.md).
Replacing it with a simple event generation script.